### PR TITLE
Update write methods for windows compatibility

### DIFF
--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -276,6 +276,8 @@ function Base.write(sp::SerialPort, data::Array{UInt8})
     return nb
 end
 
+Base.write(sp::SerialPort, data::Array{Char}) = write(sp, convert(Array{UInt8},data))
+
 Base.write(sp::SerialPort, data::String) = write(sp, convert(Array{UInt8},data))
 
 """

--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -256,6 +256,7 @@ end
 
 """
 `write(sp::SerialPort, data::String)`
+`write(sp::SerialPort, data::Array{Char})`
 `write(sp::SerialPort, data::Array{UInt8})`
 
 Write sequence of Bytes to `sp`.

--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -276,10 +276,7 @@ function Base.write(sp::SerialPort, data::Array{UInt8})
     return nb
 end
 
-function Base.write(sp::SerialPort, data::String)
-    sp_nonblocking_write(sp.ref, convert(Array{UInt8},data))
-    return sp_drain(sp.ref)
-end
+Base.write(sp::SerialPort, data::String) = write(sp, convert(Array{UInt8},data))
 
 """
 `write(sp::SerialPort, data::UInt8)`

--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -262,8 +262,19 @@ end
 Write sequence of Bytes to `sp`.
 """
 function Base.write(sp::SerialPort, data::Array{UInt8})
-    sp_nonblocking_write(sp.ref, data)
-    return sp_drain(sp.ref)
+    nb::Int = 0;
+    while nb < length(data)
+        ret::SPReturn = sp_nonblocking_write(sp.ref, data[nb+1:end])
+        if ret < SP_OK
+            break;
+        end
+        nb = nb + Int(ret)
+    end
+    ret = sp_output_waiting(sp.ref)
+    if ret > SP_OK
+        ret = sp_drain(sp.ref)
+    end
+    return nb
 end
 
 function Base.write(sp::SerialPort, data::Array{Char})

--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -298,14 +298,14 @@ Write string representation of signed integer `i` to `sp`.
 Base.write(sp::SerialPort, i::Signed) = Base.write(sp, "$i")
 
 """
-`write(sp::SerialPort, f::AbstractFloat)`
-`write(sp::SerialPort, f::AbstractFloat, format::AbstractString)`
+`write(sp::SerialPort, f::Union{Float16, Float32, Float64})`
+`write(sp::SerialPort, f::Union{Float16, Float32, Float64}, format::AbstractString)`
 
 Write formatted string representation of `f` to `sp`. By default the string is
 formated using `format="%.3f"`. For details on the format consult the
 documentation of the C library function `sprintf`.
 """
-Base.write(sp::SerialPort, f::AbstractFloat, format::AbstractString="%.3f") = Base.write(sp, eval(:@sprintf($format, $f)))
+Base.write(sp::SerialPort, f::Union{Float16, Float32, Float64}, format::AbstractString="%.3f") = Base.write(sp, eval(:@sprintf($format, $f)))
 
 """
 `eof(sp::SerialPort)`

--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -291,11 +291,11 @@ Base.write(sp::SerialPort, data::Char) = write(sp, [data])
 Base.write(sp::SerialPort, data::UInt8) = write(sp, [data])
 
 """
-`write(sp::SerialPort, i::Union{Int128, Int16, Int32, Int64})`
+`write(sp::SerialPort, i::Signed)`
 
 Write string representation of signed integer `i` to `sp`.
 """
-Base.write(sp::SerialPort, i::Union{Int128, Int16, Int32, Int64}) = Base.write(sp, "$i")
+Base.write(sp::SerialPort, i::Signed) = Base.write(sp, "$i")
 
 """
 `write(sp::SerialPort, f::AbstractFloat)`

--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -256,7 +256,6 @@ end
 
 """
 `write(sp::SerialPort, data::String)`
-`write(sp::SerialPort, data::Array{Char})`
 `write(sp::SerialPort, data::Array{UInt8})`
 
 Write sequence of Bytes to `sp`.
@@ -275,11 +274,6 @@ function Base.write(sp::SerialPort, data::Array{UInt8})
         ret = sp_drain(sp.ref)
     end
     return nb
-end
-
-function Base.write(sp::SerialPort, data::Array{Char})
-    sp_nonblocking_write(sp.ref, data)
-    return sp_drain(sp.ref)
 end
 
 function Base.write(sp::SerialPort, data::String)

--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -290,11 +290,11 @@ Base.write(sp::SerialPort, data::Char) = write(sp, [data])
 Base.write(sp::SerialPort, data::UInt8) = write(sp, [data])
 
 """
-`write(sp::SerialPort, i::Integer)`
+`write(sp::SerialPort, i::Union{Int128, Int16, Int32, Int64})`
 
-Write string representation of `i` to `sp`.
+Write string representation of signed integer `i` to `sp`.
 """
-Base.write(sp::SerialPort, i::Integer) = Base.write(sp, "$i")
+Base.write(sp::SerialPort, i::Union{Int128, Int16, Int32, Int64}) = Base.write(sp, "$i")
 
 """
 `write(sp::SerialPort, f::AbstractFloat)`


### PR DESCRIPTION
I have updated the write methods:

 1. All methods attempt to write as many bytes as possible. 
 2. All methods return an integer value of the number of bytes written.
 3. Method ambiguity with `base.write` in `io.jl` for writing a single integer string value has been cleared up.

(2.) seems to me to be expected behaviour for consistency with other IO functions but (1.) may not be. Please advise. Either way, calling `sp_drain` after `sp_nonblocking_write` on windows does not cause all requested bytes to be written.

TODO:
 - [x] Fix method ambiguity method ambiguity with `base.write` in `io.jl` for writing a single floating point number's string value. 
 - [ ] Test on macOS/linux.