### PR TITLE
nonblocking readuntil

### DIFF
--- a/src/high-level-api.jl
+++ b/src/high-level-api.jl
@@ -372,6 +372,7 @@ function Base.readuntil(sp::SerialPort, delim::Vector{Char}, timeout_ms::Real)
                 break
             end
         end
+        yield()
     end
     return String(take!(out))
 end


### PR DESCRIPTION
I needed a nonblocking version of readuntil().
I have to admit I am not very versed regarding concurrency
but I just tried adding a yield() and it worked for me.

What do you think of this?