### PR TITLE
return port info to user so it can be parsed.  Also fix a bug.

### DIFF
--- a/src/LibSerialPort.jl
+++ b/src/LibSerialPort.jl
@@ -284,24 +284,26 @@ end
     list_ports([nports_guess::Integer])`
 
 Print a list of currently visible ports, along with some basic info.
+Also return that info in an array so that user can parse and look for the right port to use.
 
 `nports_guess` provides the number of ports guessed. Its default is `64`.
 """
 function list_ports(;nports_guess::Integer=64)
     ports = sp_list_ports()
 
+    portinfo = []
     for port in unsafe_wrap(Array, ports, nports_guess, own=false)
-        port == C_NULL && return
+        port == C_NULL && break
 
         println(sp_get_port_name(port))
         println("\tDescription:\t",    sp_get_port_description(port))
         println("\tTransport type:\t", sp_get_port_transport(port))
+        push!(portinfo,[sp_get_port_name(port),sp_get_port_description(port),sp_get_port_transport(port)])
+        println(portinfo)
     end
-
     sp_free_port_list(ports)
-    return nothing
+    return portinfo
 end
-
 
 """
     get_port_list([nports_guess::Integer])


### PR DESCRIPTION
list_ports collects useful info on ports, but just prints it to the console, which is not useful for parsing.  By returning all that data to the user, it can be parsed to find the desired serial port device automatically.

Also, the "port == C_NULL && return" line causes the sp_free_port_list(ports) call to never be called.  This is also fixed in this pull request.